### PR TITLE
将 text 模块输出

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,3 +1,4 @@
 exports.style = require('./tasks/lib/style');
 exports.script = require('./tasks/lib/script');
 exports.template = require('./tasks/lib/template');
+exports.text = require('./tasks/lib/text');


### PR DESCRIPTION
在自定义 parser 的时候发现这里遗漏了对 text 模块的输出

另外有一个疑惑的地方是，默认的 css parser 为什么不是 css2jsParser 呢？
也许 Alipay 是对 css 上有一些特殊的处理逻辑，但是我估计大部分普通的使用者是用不着这些处理逻辑的
如果默认 parser 改为 css2js 的话，自定义 Grunt 的时候就不必这么麻烦了

```
var transport = require('grunt-cmd-transport');
var style = transport.style.init(grunt);
var text = transport.text.init(grunt);
var script = transport.script.init(grunt);

grunt.initConfig({
    transport : {
        spm : {
            options : {
                parsers: {
                    '.js': [script.jsParser],
                    '.css': [style.css2jsParser],
                    '.html': [text.html2jsParser]
                }
            },
```

或者其实 Grunt 这里还有更简单的做法而我又没发现？
