### PR TITLE
Fix: difference between `alias` path and module id

### DIFF
--- a/tasks/transport.js
+++ b/tasks/transport.js
@@ -61,6 +61,24 @@ module.exports = function(grunt) {
       options.process = {};
     }
 
+    // parse alias for normal id
+    for(var i in options.alias)
+    {
+      options.paths.some(function(base) {
+        var filepath = path.join(base, options.alias[i]);
+        var extname = path.extname(filepath);
+        if (!extname) {
+          filepath += '.js';
+        }
+        if (grunt.file.exists(filepath)) {
+          filepath = path.relative(base, filepath).replace(/\\/g, '/');
+          grunt.log.verbose.writeln('alias find module "' + filepath + '"');
+          options.alias[i] = extname ? filepath : filepath.replace(/\.js$/, '');
+          return true;
+        }
+      });
+    }
+
     var count = 0;
     this.files.forEach(function(fileObj) {
       // cwd shouldn't exist after normalize path


### PR DESCRIPTION
对传入的`alias` options进行预处理，确保`alias`值和实际编译结果`define`的id一致

例如：
`alias`如下：

```
{
jquery: '/com/jquery',
backbone: 'com/./backbone'
}
```

生成的define却是这样的

```
define('com/jquery', [], ...)
define('com/backbone', ['com/jquery'], ...)
```
